### PR TITLE
Added support to only update orb for JSON attributes on topics that w…

### DIFF
--- a/firmware/include/widgets/mqttWidget.h
+++ b/firmware/include/widgets/mqttWidget.h
@@ -25,6 +25,7 @@ struct OrbConfig {
     String orbvalunit;      // value unit
     int orbsize;            // font size
     String jsonField;       // JSON field to extract
+    std::map<String, String> lastValuesMap; // Store last values for fields
 };
 
 class MQTTWidget : public Widget {


### PR DESCRIPTION
…e're showing.

There is already existing support to only redraw the orb if there is an update on the MQTT topic.  However, if the topic has more attributes and these are updating, this was causing the orb to update - even though nothing visually really changed.  This change reduces the flicker/redraw considerably - only updating the orb for the json attribute that is being displayed.